### PR TITLE
Feat: Set climb direction

### DIFF
--- a/1984/Assets/Scripts/Runtime/UI/Platformer/ClimbState.cs
+++ b/1984/Assets/Scripts/Runtime/UI/Platformer/ClimbState.cs
@@ -31,7 +31,17 @@ public class ClimbState : IState
         rigidbody.bodyType = RigidbodyType2D.Kinematic;
         rigidbody.velocity = Vector2.zero;
         playerPos = stateController.transform.position;
-        stateController.transform.position = Vector3.MoveTowards(playerPos, new Vector3(ladderPos.x, playerPos.y, 0), 0.6f);
+        Vector3 startPos;
+
+        if (playerPos.x <= ladderPos.x)
+        {
+            startPos = new Vector3(ladderPos.x - 0.5f, playerPos.y, 0);
+        }
+        else
+        {
+            startPos = new Vector3(ladderPos.x + 0.5f, playerPos.y, 0);
+        }
+        stateController.transform.position = Vector3.MoveTowards(playerPos, startPos, 3.0f);
 
     }
 


### PR DESCRIPTION
게임 속에서 사다리가 한쪽 방향만 필요한지 양쪽 다 필요한지 아직은 모르니까
일단 플레이어의 접근 방향에 따라 사다리 오르기 시작하는 위치를 왼, 오로 나누어 구분했어

사다리 기준으로 플레이어 위치가
왼쪽이면 사다리에서 조금 왼쪽에서 올라가고
오른쪽이면 오른쪽에서 올라가도록 함!